### PR TITLE
Add indri search provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+lib/
 
 # Typescript v1 declaration files
 typings/

--- a/app/services/search/index.js
+++ b/app/services/search/index.js
@@ -39,7 +39,7 @@ exports.search = async function (query, vertical, pageNumber, sessionId, userId,
  */
 async function addMetadata(results, sessionId, userId) {
     const promises = results.map(async (result) => {
-        const id = result.docid ? result.docid : result.url;
+        const id = result.id ? result.id : result.url;
         result.metadata = {
             bookmark: await bookmark.getBookmark(sessionId, id),
             annotations: (await annotation.getAnnotations(sessionId, id)).length,

--- a/app/services/search/index.js
+++ b/app/services/search/index.js
@@ -39,10 +39,11 @@ exports.search = async function (query, vertical, pageNumber, sessionId, userId,
  */
 async function addMetadata(results, sessionId, userId) {
     const promises = results.map(async (result) => {
+        const id = result.docid ? result.docid : result.url;
         result.metadata = {
-            bookmark: await bookmark.getBookmark(sessionId, result.url),
-            annotations: (await annotation.getAnnotations(sessionId, result.url)).length,
-            rating: (await rating.getRating(sessionId, result.url, userId)).total,
+            bookmark: await bookmark.getBookmark(sessionId, id),
+            annotations: (await annotation.getAnnotations(sessionId, id)).length,
+            rating: (await rating.getRating(sessionId, id, userId)).total,
             views: await view.getViews(sessionId, result.url),
         };
 

--- a/app/services/search/provider.js
+++ b/app/services/search/provider.js
@@ -2,11 +2,13 @@
 
 const bing = require('./providers/bing');
 const elasticsearch = require('./providers/elasticsearch');
+const indri = require('./providers/indri');
 
 // mapping of providerName to search provider module
 const providers = {
-    bing: bing,
-    elasticsearch: elasticsearch
+    'bing': bing,
+    'elasticsearch': elasticsearch,
+    'indri': indri
 };
 
 /*
@@ -16,8 +18,9 @@ const providers = {
  * @params {vertical} type of search results (web, images, etc)
  * @params {pageNumber} result pagination number
  * @params {providerName} the name of the search provider to use (bing by default)
+ * @params {relevanceFeedbackDocuments} the set of documents to use for relevance feedback (if supported by provider)
  */
-exports.fetch = function (query, vertical, pageNumber, providerName) {
+exports.fetch = function (query, vertical, pageNumber, providerName, relevanceFeedbackDocuments) {
     if (!(providerName in providers)) {
         return Promise.reject({
             name: 'Bad Request',
@@ -26,5 +29,5 @@ exports.fetch = function (query, vertical, pageNumber, providerName) {
     }
     let provider = providers[providerName];
 
-    return provider.fetch(query, vertical, pageNumber);
+    return provider.fetch(query, vertical, pageNumber, relevanceFeedbackDocuments);
 };

--- a/app/services/search/providers/bing.js
+++ b/app/services/search/providers/bing.js
@@ -9,9 +9,9 @@ const BingApi = require('node-bing-api')({
 /*
  * Fetches data from bing
  *
- * @params {params} the search parameters
+ * @params {query} the search query string
  * @params {vertical} type of search results (web, images, etc)
- * @params {callback} the callback function that is executed once the request returns
+ * @params {pageNumber} the number of the page of results to show (1-based indexing)
  */
 exports.fetch = function (query, vertical, pageNumber) {
     return new Promise(function (resolve, reject) {

--- a/app/services/search/providers/indri.js
+++ b/app/services/search/providers/indri.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const indri = require('../../../../lib/node-indri/node-indri');
+const searcher = new indri.Searcher({
+    "index": "./lib/node-indri/etc/poems_index",
+    "rules" : "method:dirichlet,mu:1000",
+    "fbTerms": 10,
+    "fbMu": 1500,
+    "includeFields": { "title": "headline", "docno": "docno"},
+    "includeDocument" : true,
+    "resultsPerPage": 10
+});
+
+const verticals = [
+    'web'
+];
+
+/*
+ * Fetches data from indri
+ *
+ * @params {query} the search query string
+ * @params {vertical} type of search results (web, images, etc)
+ * @params {pageNumber} the number of the page of results to show (1-based indexing)
+ * @params {relevanceFeedbackDocuments} the set of documents to use for relevance feedback
+ */
+exports.fetch = function (query, vertical, pageNumber, relevanceFeedbackDocuments) {
+    if (!verticals.includes(vertical)) {
+        throw {
+            name: 'Bad Request',
+            message: 'Invalid vertical'
+        }
+    }
+
+    return new Promise(function (resolve, reject) {
+        const callback = function (error, results) {
+            if (error) return reject(error);
+            resolve(formatResults(results));
+        };
+
+        searcher.search(query, pageNumber, relevanceFeedbackDocuments, callback);
+    });
+};
+
+
+function formatResults(results) {
+    return {
+        results: results
+    };
+}

--- a/app/services/search/providers/indri.js
+++ b/app/services/search/providers/indri.js
@@ -6,13 +6,13 @@ const searcher = new indri.Searcher({
     "rules" : "method:dirichlet,mu:1000",
     "fbTerms": 10,
     "fbMu": 1500,
-    "includeFields": { "headline": "title", "docno": "docno"},
+    "includeFields": { "title": "title", "docno": "docno"},
     "includeDocument" : true,
     "resultsPerPage": 10
 });
 
 const verticals = [
-    'web'
+    'text'
 ];
 
 /*

--- a/app/services/search/providers/indri.js
+++ b/app/services/search/providers/indri.js
@@ -6,7 +6,7 @@ const searcher = new indri.Searcher({
     "rules" : "method:dirichlet,mu:1000",
     "fbTerms": 10,
     "fbMu": 1500,
-    "includeFields": { "title": "headline", "docno": "docno"},
+    "includeFields": { "headline": "title", "docno": "docno"},
     "includeDocument" : true,
     "resultsPerPage": 10
 });
@@ -36,7 +36,7 @@ exports.fetch = function (query, vertical, pageNumber, relevanceFeedbackDocument
             if (error) return reject(error);
             resolve(formatResults(results));
         };
-
+        relevanceFeedbackDocuments = relevanceFeedbackDocuments.map(string => parseInt(string));
         searcher.search(query, pageNumber, relevanceFeedbackDocuments, callback);
     });
 };

--- a/app/services/search/providers/indri.js
+++ b/app/services/search/providers/indri.js
@@ -6,7 +6,13 @@ const searcher = new indri.Searcher({
     "rules" : "method:dirichlet,mu:1000",
     "fbTerms": 10,
     "fbMu": 1500,
-    "includeFields": { "title": "title", "docno": "docno"},
+    "includeFields": {
+        "title": "title",
+        "docno": "docno",
+        "date": "date",
+        "source": "source",
+        "text": "text"
+    },
     "includeDocument" : true,
     "resultsPerPage": 10
 });

--- a/app/services/search/providers/indri.js
+++ b/app/services/search/providers/indri.js
@@ -2,7 +2,7 @@
 
 const indri = require('../../../../lib/node-indri/node-indri');
 const searcher = new indri.Searcher({
-    "index": "./lib/node-indri/etc/poems_index",
+    "index": "../data/Aquaint-Index",
     "rules" : "method:dirichlet,mu:1000",
     "fbTerms": 10,
     "fbMu": 1500,
@@ -50,6 +50,14 @@ exports.fetch = function (query, vertical, pageNumber, relevanceFeedbackDocument
 
 function formatResults(results) {
     return {
-        results: results
+        results: results.map(result => ({
+            id: result.docid,
+            collectionId: result.fields.docno,
+            name: result.fields.title,
+            date: result.fields.date,
+            source: result.fields.source,
+            snippet: result.snippet,
+            text: result.fields.text
+        }))
     };
 }

--- a/app/services/search/regulator.js
+++ b/app/services/search/regulator.js
@@ -49,6 +49,9 @@ exports.fetch = async function (query, vertical, pageNumber, sessionId, userId, 
             response = await provider.fetch(query, vertical, pageNumber + i, providerName, []);
         }
         let filteredResults = response.results;
+        if (filteredResults.length === 0) {
+            break
+        }
         if (distributionOfLabour === "unbookmarkedOnly") {
             filteredResults = filteredResults.filter(resultsFilter(bookmarkUrls));
         }

--- a/app/services/search/regulator.js
+++ b/app/services/search/regulator.js
@@ -4,7 +4,8 @@ const provider = require('./provider');
 const bookmark = require('../../services/features/bookmark');
 
 /*
- * Fetches search results from the provider and applies algorithmic mediation
+ * Fetches search results from the provider, applies algorithmic mediation and ensures that all required fields
+ * are included in results.
  *
  * @params {query} the search query
  * @params (vertical) type of search results (web, images, etc)
@@ -69,10 +70,31 @@ exports.fetch = async function (query, vertical, pageNumber, sessionId, userId, 
         accumulatedResults = accumulatedResults.slice(0, count +
             (accumulatedResults.length - accumulatedResults.filter(resultsFilter(bookmarkUrls)).length));
     }
+    accumulatedResults = addMissingFields(accumulatedResults);
     response.results = accumulatedResults;
     return response
 };
 
 function resultsFilter(bookmarkedUrls) {
     return result => !bookmarkedUrls.includes(result.url)
+}
+
+/**
+ * Add required fields when missing
+ * @param results the set of results to add missing fields to
+ * @returns set of results with missing fields added
+ */
+function addMissingFields(results) {
+    return results.map(result => {
+        if (!result.name.replace(/\s/g,'')) {
+            result.name = "Untitled";
+        }
+        if (result.id && !result.text.replace(/\s/g,'')) {
+            result.text = "No text available"
+        }
+        if (!result.snippet.replace(/\s/g,'')) {
+            result.snippet = "No text available"
+        }
+        return result;
+    });
 }


### PR DESCRIPTION
The indri search provider uses node-indri to provide full-text search with support for relevance feedback using the indri search engine.